### PR TITLE
sale_minimum_margin: prevent muliple chatter messages

### DIFF
--- a/sale_minimum_margin/margin_update_from_category.py
+++ b/sale_minimum_margin/margin_update_from_category.py
@@ -32,7 +32,6 @@ class Product(models.Model):
             category=self.categ_id.display_name,
         )
         self.message_post(body=message)
-
         only_one_variant = (
             self.product_tmpl_id.product_variant_ids == self
         )


### PR DESCRIPTION
The constraint must not be raised on product template if it has multiple variants.
Otherwise, when the constraint is raised on a variant, it will be raised on the template as well
because the field margin on product.template depends on the field margin on product.product.