### PR TITLE
TA#21530 Set quantity based on rental dates

### DIFF
--- a/sale_rental/models/sale_order_line.py
+++ b/sale_rental/models/sale_order_line.py
@@ -37,6 +37,19 @@ class SaleOrderLine(models.Model):
         if self._is_rented_kit() or self._is_rented_kit_component():
             self.price_unit = 0
 
+    @api.onchange("rental_date_from", "rental_date_to")
+    def onchange_rental_dates(self):
+        if self.is_rental_service and self.rental_date_from and self.rental_date_to:
+            self._force_rental_date_to_after_date_from()
+            self.product_uom_qty = self._get_qty_based_on_rental_dates()
+
+    def _force_rental_date_to_after_date_from(self):
+        self.rental_date_to = max(self.rental_date_from, self.rental_date_to)
+
+    def _get_qty_based_on_rental_dates(self):
+        number_of_days = (self.rental_date_to - self.rental_date_from).days
+        return max(number_of_days + 1, 0)
+
     @api.multi
     def _compute_tax_id(self):
         super()._compute_tax_id()

--- a/sale_rental/tests/test_sale_order_line_dates.py
+++ b/sale_rental/tests/test_sale_order_line_dates.py
@@ -1,10 +1,12 @@
 # © 2020 Numigi (tm) and all its contributors (https://bit.ly/numigiens)
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
+from ddt import ddt, data, unpack
 from datetime import datetime, timedelta
 from .common import SaleOrderKitCase
 
 
+@ddt
 class TestSaleOrderLineDeliveredQty(SaleOrderKitCase):
     def test_rental_date_from_propagated_to_kit_lines(self):
         date_from = datetime.now() + timedelta(10)
@@ -37,3 +39,24 @@ class TestSaleOrderLineDeliveredQty(SaleOrderKitCase):
         self.make_service_line("K2", self.rental_service, date_from, date_to, 1)
         assert self.component_2a.expected_rental_date == date_from
         assert self.component_2a.expected_return_date == date_to
+
+    @data(
+        (datetime(2020, 1, 1), datetime(2020, 1, 1, 23, 59, 59), 1),
+        (datetime(2020, 1, 1), datetime(2020, 1, 2), 2),
+        (datetime(2020, 1, 1), datetime(2020, 1, 2, 23, 59, 59), 2),
+        (datetime(2020, 1, 1), datetime(2020, 1, 3), 3),
+    )
+    @unpack
+    def test_onchange_rental_dates(self, date_from, date_to, quantity):
+        self.service_1.rental_date_from = date_from
+        self.service_1.rental_date_to = date_to
+        self.service_1.onchange_rental_dates()
+        assert self.service_1.product_uom_qty == quantity
+
+    def test_onchange_rental_dates__date_to_forced_after_date_from(self):
+        date_from = datetime(2020, 1, 3)
+        self.service_1.rental_date_from = date_from
+        self.service_1.rental_date_to = datetime(2020, 1, 1)
+        self.service_1.onchange_rental_dates()
+        assert self.service_1.rental_date_to == date_from
+        assert self.service_1.product_uom_qty == 1


### PR DESCRIPTION
Automatically fill (onchange) the quantity of the rental service line when the
rental from/to dates are selected by the user.