### PR TITLE
TA#32084 exclude cancelled attendees

### DIFF
--- a/event_sale_order_status/__manifest__.py
+++ b/event_sale_order_status/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Event Sale Order Status",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "author": "Numigi",
     "maintainer": "Numigi",
     "website": "https://bit.ly/numigi-com",

--- a/event_sale_order_status/models/event_event.py
+++ b/event_sale_order_status/models/event_event.py
@@ -17,5 +17,6 @@ class Event(models.Model):
             event.confirmed_attendees_count = len(
                 event.registration_ids.filtered(
                     lambda r: r.sale_order_id.state in ("sale", "done")
+                    and r.state != "cancel"
                 )
             )

--- a/event_sale_order_status/views/event_event.xml
+++ b/event_sale_order_status/views/event_event.xml
@@ -10,6 +10,7 @@
             'default_event_id': active_id,
             'search_default_event_id': active_id,
             'search_default_confirmed_sale_order': True,
+            'search_default_expected': True,
         }</field>
     </record>
 

--- a/event_sale_order_status/views/event_registration.xml
+++ b/event_sale_order_status/views/event_registration.xml
@@ -30,7 +30,8 @@
         <field name="arch" type="xml">
             <field name="event_id" position="before">
                 <separator/>
-                <filter string="Confirmed Sale Order" name="confirmed_sale_order" domain="[('sale_order_id.state', 'in', ['sale', 'done'])]"/>
+                <filter string="Confirmed Sale Order" name="confirmed_sale_order"
+                    domain="[('sale_order_id.state', 'in', ['sale', 'done'])]"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
Exclude unexpected attendees from the Confirmed smart button,
event if they are linked to a confirmed SO.