### PR TITLE
TA#35956 prevent odoobot as seller on invoices

### DIFF
--- a/sale_intercompany_service/tests/test_interco_service.py
+++ b/sale_intercompany_service/tests/test_interco_service.py
@@ -323,6 +323,7 @@ class TestIntercoInvoices(IntercoServiceCase):
         assert invoice.account_id.internal_type == "payable"
         assert invoice.account_id.company_id == self.subsidiary
         assert invoice.amount_tax
+        assert not invoice.user_id
 
     def test_interco_supplier_invoice_line(self):
         line = self.supplier_invoice_line
@@ -350,6 +351,7 @@ class TestIntercoInvoices(IntercoServiceCase):
         assert invoice.account_id.company_id == self.subsidiary
         assert invoice.partner_shipping_id == self.delivery_address
         assert invoice.amount_tax
+        assert not invoice.user_id
 
     def test_interco_customer_invoice_line(self):
         line = self.customer_invoice_line

--- a/sale_intercompany_service/wizard/sale_interco_service_invoice.py
+++ b/sale_intercompany_service/wizard/sale_interco_service_invoice.py
@@ -227,6 +227,7 @@ class SaleIntercoServiceInvoice(models.TransientModel):
                 "fiscal_position_id": self.supplier_position_id.id,
                 "interco_service_order_id": self.order_id.id,
                 "is_interco_service": True,
+                "user_id": None,
             }
         )
 
@@ -287,6 +288,7 @@ class SaleIntercoServiceInvoice(models.TransientModel):
                 "fiscal_position_id": self.customer_position_id.id,
                 "interco_service_order_id": self.order_id.id,
                 "is_interco_service": True,
+                "user_id": None,
             }
         )
 


### PR DESCRIPTION
By default, when an invoice is created with sudo,
odoobot is assigned as user.

This generates issues with intercompany rules when
sending the confirmation email.