### PR TITLE
TA#30212 fix access to buttons for team managers and users

### DIFF
--- a/commission/models/commission_target.py
+++ b/commission/models/commission_target.py
@@ -127,14 +127,18 @@ class CommissionTarget(models.Model):
 
     def _compute_show_invoices(self):
         for target in self:
-            target.show_invoices = target.basis == "my_sales"
+            target.show_invoices = (
+                target.state != "draft" and target.basis == "my_sales"
+            )
 
     def _compute_show_child_targets(self):
         for target in self:
-            target.show_child_targets = target.basis == "my_team_commissions"
+            target.show_child_targets = (
+                target.state != "draft" and target.basis == "my_team_commissions"
+            )
 
     def compute(self):
-        self.check_extended_security_read()
+        self.check_extended_security_write()
         self = self.sudo()
 
         for target in self._sorted_by_category_dependency():
@@ -434,5 +438,6 @@ class CommissionTarget(models.Model):
     @api.model
     def get_read_access_actions(self):
         res = super().get_read_access_actions()
-        res.append("compute")
+        res.append("view_invoice_lines")
+        res.append("view_child_targets")
         return res

--- a/commission/tests/common.py
+++ b/commission/tests/common.py
@@ -14,8 +14,13 @@ class TestCommissionCase(SavepointCase):
 
         cls.user = cls._create_user()
         cls.user.groups_id = cls.env.ref("commission.group_user")
-
         cls.employee = cls._create_employee(user=cls.user)
+
+        cls.manager_user = cls._create_user(
+            name="Manager", email="manager@testmail.com"
+        )
+        cls.manager_user.groups_id = cls.env.ref("commission.group_manager")
+        cls.manager = cls._create_employee(user=cls.manager_user)
 
         cls.customer = cls.env["res.partner"].create({"name": "testing"})
 

--- a/commission/tests/test_commission_personal.py
+++ b/commission/tests/test_commission_personal.py
@@ -53,9 +53,15 @@ class TestCommissionPersonal(TestCommissionCase):
         cls.excluded_tag = cls.env["sale.order.tag"].create({"name": "Tables"})
 
     def test_compute_show_invoices(self):
+        self.target.set_confirmed_state()
         assert self.target.show_invoices
 
+    def test_compute_show_invoices__draft_state(self):
+        self.target.set_draft_state()
+        assert not self.target.show_invoices
+
     def test_compute_show_child_targets(self):
+        self.target.set_confirmed_state()
         assert not self.target.show_child_targets
 
     def test_view_invoice_lines(self):
@@ -197,10 +203,9 @@ class TestCommissionPersonal(TestCommissionCase):
         self.target.set_draft_state()
         assert self.target.state == "draft"
 
-    def test_compute_not_own_commission(self):
-        self.target.employee_id = self._create_employee()
+    def test_employee_can_not_compute_commissions(self):
         with pytest.raises(AccessError):
-            self._compute_target()
+            self.target.sudo(self.user).compute()
 
     def test_target_access_domain(self):
         targets = self._search_employee_targets()
@@ -212,7 +217,7 @@ class TestCommissionPersonal(TestCommissionCase):
         assert not targets
 
     def _compute_target(self):
-        self.target.sudo(self.user).compute()
+        self.target.sudo(self.manager_user).compute()
 
     def _search_employee_targets(self):
         domain = (

--- a/commission/tests/test_commission_team.py
+++ b/commission/tests/test_commission_team.py
@@ -14,26 +14,26 @@ class TestCommissionTeam(TestCommissionCase):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.manager_user = cls._create_user(
-            name="Manager", email="manager@testmail.com"
+        cls.team_manager_user = cls._create_user(
+            name="TeamManager", email="team-manager@testmail.com"
         )
-        cls.manager_user.groups_id = cls.env.ref("commission.group_team_manager")
+        cls.team_manager_user.groups_id = cls.env.ref("commission.group_team_manager")
 
-        cls.manager = cls._create_employee(user=cls.manager_user)
+        cls.team_manager = cls._create_employee(user=cls.team_manager_user)
 
-        cls.manager_category = cls._create_category(
+        cls.team_category = cls._create_category(
             name="Manager", basis="my_team_commissions"
         )
 
         cls.manager_target = cls._create_target(
-            employee=cls.manager,
-            category=cls.manager_category,
+            employee=cls.team_manager,
+            category=cls.team_category,
             target_amount=40000,
             fixed_rate=0.05,
         )
-        cls.manager_category.child_category_ids = cls.category
+        cls.team_category.child_category_ids = cls.category
 
-        cls.team = cls._create_team("Testing", cls.manager_user)
+        cls.team = cls._create_team("Testing", cls.team_manager_user)
         cls.manager_target.included_teams_ids |= cls.team
 
         cls.user.sale_team_id = cls.team
@@ -42,10 +42,16 @@ class TestCommissionTeam(TestCommissionCase):
         cls.interval_rate = 0.05
 
     def test_compute_show_invoices(self):
+        self.manager_target.set_confirmed_state()
         assert not self.manager_target.show_invoices
 
     def test_compute_show_child_targets(self):
+        self.manager_target.set_confirmed_state()
         assert self.manager_target.show_child_targets
+
+    def test_compute_show_child_targets__draft_state(self):
+        self.manager_target.set_draft_state()
+        assert not self.manager_target.show_child_targets
 
     def test_view_child_targets(self):
         self.manager_target.child_target_ids = self.employee_target
@@ -66,7 +72,7 @@ class TestCommissionTeam(TestCommissionCase):
         assert self.manager_target.base_amount == 2000
 
     def test_multiple_teams(self):
-        new_team = self._create_team("Multi", self.manager_user)
+        new_team = self._create_team("Multi", self.team_manager_user)
         self.manager_target.included_teams_ids |= new_team
 
         new_user = self._create_user(name="Bob")
@@ -118,7 +124,7 @@ class TestCommissionTeam(TestCommissionCase):
     @unpack
     def test_manager_completion_interval(self, slice_from, slice_to, completion):
         rate = self._create_target_rate(self.manager_target, slice_from, slice_to)
-        self.manager_category.rate_type = "interval"
+        self.team_category.rate_type = "interval"
         self.employee_target.total_amount = 400000 * 0.05
         self._compute_manager_target()
         assert rate.completion_rate == completion
@@ -138,7 +144,7 @@ class TestCommissionTeam(TestCommissionCase):
             slice_to,
             self.interval_rate,
         )
-        self.manager_category.rate_type = "interval"
+        self.team_category.rate_type = "interval"
         self.employee_target.total_amount = 400000 * 0.05
         self._compute_manager_target()
         assert rate.subtotal == subtotal
@@ -151,7 +157,7 @@ class TestCommissionTeam(TestCommissionCase):
         assert rset[1] == self.manager_target
 
     def test_no_child_categories(self):
-        self.manager_category.child_category_ids = None
+        self.team_category.child_category_ids = None
         self.employee_target.total_amount = 400000 * 0.05
         self._compute_manager_target()
         assert self.manager_target.total_amount == 0
@@ -183,19 +189,6 @@ class TestCommissionTeam(TestCommissionCase):
             "commission_percentage"
         ) == self.employee_target.rate_ids.mapped("commission_percentage")
 
-    def test_compute_not_own_target(self):
-        self.manager_target.employee_id = self._create_employee()
-        with pytest.raises(AccessError):
-            self._compute_manager_target()
-
-    def test_compute_target_of_employee_in_own_team(self):
-        self._compute_employee_target()
-
-    def test_compute_target_of_employee_not_in_own_team(self):
-        self.team.user_id = self._create_employee().user_id
-        with pytest.raises(AccessError):
-            self._compute_employee_target()
-
     def test_target_access_domain(self):
         targets = self._search_manager_targets()
         assert targets == self.employee_target | self.manager_target
@@ -209,7 +202,7 @@ class TestCommissionTeam(TestCommissionCase):
     def _search_manager_targets(self):
         domain = (
             self.env["commission.target"]
-            .sudo(self.manager_user)
+            .sudo(self.team_manager_user)
             .get_extended_security_domain()
         )
         return self.env["commission.target"].search(domain)

--- a/commission/tests/test_views.py
+++ b/commission/tests/test_views.py
@@ -1,14 +1,21 @@
 # © 2021 - today Numigi (tm) and all its contributors (https://bit.ly/numigiens)
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
+from ddt import ddt, data
 from lxml import etree
 from .common import TestCommissionCase
 
 
+@ddt
 class TestViews(TestCommissionCase):
-    def test_compute_button_is_visible_for_basic_users(self):
+
+    @data(
+        "view_invoice_lines",
+        "view_child_targets",
+    )
+    def test_buttons_is_visible_for_basic_users(self, button_name):
         form = self._get_commission_target_form(self.user)
-        assert form.xpath("//button[@name='compute']")
+        assert form.xpath(f"//button[@name='{button_name}']")
 
     def _get_commission_target_form(self, user):
         view = self.env.ref("commission.commission_target_form")


### PR DESCRIPTION
Only commission managers are able to compute targets.

However, team users and basic users can click to view related
invoices or related targets.