### PR TITLE
TA#39562 Clean the salesperson assign wizard

### DIFF
--- a/crm_assign_by_area/wizard/assign_salesperson_by_area_wizard.xml
+++ b/crm_assign_by_area/wizard/assign_salesperson_by_area_wizard.xml
@@ -28,7 +28,7 @@
                             name="action_confirm"
                             type="object"
                             class="oe_highlight"
-                            attrs="{'invisible': ['|', ('wizard_msg', 'ilike', 'There is no salesperson to assign'),('wizard_msg', 'ilike', 'Aucun vendeur disponible')]}"
+                            attrs="{'invisible': [('salesperson_id', '=', False)]}"
                     />
                     <button string="Cancel" class="oe_link" special="cancel"/>
                 </footer>


### PR DESCRIPTION
Make the message computed instead of based on onchange function.
Otherwise, the message disapears if an error is raised by clicking on the confirm button.

Also, remove visibility modifier based on arbitrary string.