### PR TITLE
TA#40382 prevent access error on picking confirmation

### DIFF
--- a/sale_rental/models/stock_move.py
+++ b/sale_rental/models/stock_move.py
@@ -33,14 +33,14 @@ class StockMove(models.Model):
     def _action_done(self):
         result = super()._action_done()
 
-        important_rental_moves = self.filtered(
+        important_rental_moves = self.sudo().filtered(
             lambda m: m.is_important_component_move() and m.is_rental_move()
         )
         for move in important_rental_moves:
             move._update_sale_rental_service_line_delivered_qty()
             move._update_sale_rental_service_line_date_from()
 
-        important_return_moves = self.filtered(
+        important_return_moves = self.sudo().filtered(
             lambda m: m.is_important_component_move() and m.is_rental_return_move()
         )
         for move in important_return_moves:

--- a/sale_rental/tests/common.py
+++ b/sale_rental/tests/common.py
@@ -8,6 +8,9 @@ class RentalCase(KitCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.stock_user = cls.env.ref("base.user_demo")
+        cls.stock_user.groups_id = cls.env.ref("stock.group_stock_user")
+
         cls.warehouse = cls.env.ref("stock.warehouse0")
         cls.uom_day = cls.env.ref("uom.product_uom_day")
         cls.rental_service = cls.env["product.product"].create(
@@ -94,7 +97,7 @@ class RentalCase(KitCase):
     @classmethod
     def process_move(cls, move, qty):
         move._set_quantity_done(qty)
-        move._action_done()
+        move.sudo(cls.stock_user)._action_done()
 
 
 class SaleOrderKitCase(RentalCase):

--- a/sale_stock_move_no_merge/models/stock_move.py
+++ b/sale_stock_move_no_merge/models/stock_move.py
@@ -12,6 +12,7 @@ class StockMove(models.Model):
         'sale.order.line',
         'Destination Sale Order Line',
         compute='_compute_destination_sale_line_id',
+        compute_sudo=True,
     )
 
     def _compute_destination_sale_line_id(self):


### PR DESCRIPTION
The user that processes a stock picking does not need to have
access to the related sale order.