### PR TITLE
TA#40649 allow to assign sales person to a lead

### DIFF
--- a/crm_assign_by_area/__manifest__.py
+++ b/crm_assign_by_area/__manifest__.py
@@ -9,7 +9,7 @@
     "author": "Numigi",
     "maintainer": "Numigi",
     "license": "LGPL-3",
-    "depends": ["forward_sorting_area", "crm"],
+    "depends": ["crm_forward_sorting_area"],
     "data": [
         "views/crm_lead.xml",
         "views/res_partner.xml",

--- a/crm_assign_by_area/models/crm_lead.py
+++ b/crm_assign_by_area/models/crm_lead.py
@@ -11,8 +11,6 @@ class CrmLead(models.Model):
     @api.multi
     def action_assign_salesperson(self):
         self.ensure_one()
-        if not self.partner_id:
-            raise ValidationError(_("Please select a customer to assign salesperson."))
         return {
             "name": _("Assign Salesperson"),
             "type": "ir.actions.act_window",

--- a/crm_assign_by_area/tests/test_crm_assign_by_area.py
+++ b/crm_assign_by_area/tests/test_crm_assign_by_area.py
@@ -56,45 +56,37 @@ class TestCRMAssignByArea(SavepointCase):
 
         # Partner
         cls.partner = cls.env["res.partner"].create({"name": "Partner"})
-        cls.crm = cls.env["crm.lead"].create(
-            {"name": "Pipeline", "partner_id": cls.partner.id}
-        )
+        cls.lead = cls.env["crm.lead"].create({"name": "Pipeline"})
 
         wizard_env = cls.env["assign.salesperson.by.area.wizard"]
         cls.wizard_crm_env = wizard_env.with_context(
-            active_id=cls.crm.id, active_model="crm.lead"
+            active_id=cls.lead.id, active_model="crm.lead"
         )
         cls.wizard_partner_env = wizard_env.with_context(
             active_id=cls.partner.id, active_model="res.partner"
         )
 
-    def test_crm_cannot_assign_salesperson_if_crm_has_no_customer(self):
-        with self.assertRaises(ValidationError):
-            self.env["crm.lead"].create(
-                {"name": "Pipeline"}
-            ).action_assign_salesperson()
-
     def test_crm_assign_salesperson_case_no_salesperson_to_assign(self):
-        self.partner.zip = "100000"
+        self.lead.zip = "100000"
         with Form(self.wizard_crm_env) as wizard:
             res = wizard.save()
             with self.assertRaises(AssertionError):
                 res.action_confirm()
 
     def test_crm_assign_salesperson_case_one_salesperson_to_assign(self):
-        self.partner.zip = "200000"
+        self.lead.zip = "200000"
         with Form(self.wizard_crm_env) as wizard:
             res = wizard.save()
             res.action_confirm()
-            self.assertEqual(self.crm.user_id, self.user_1)
+            self.assertEqual(self.lead.user_id, self.user_1)
 
     def test_crm_assign_salesperson_case_several_salesperson_to_assign(self):
-        self.partner.zip = "300000"
+        self.lead.zip = "300000"
         with Form(self.wizard_crm_env) as wizard:
             wizard.salesperson_id = self.user_1
             res = wizard.save()
             res.action_confirm()
-            self.assertEqual(self.crm.user_id, self.user_1)
+            self.assertEqual(self.lead.user_id, self.user_1)
 
     def test_partner_assign_salesperson_case_no_salesperson_to_assign(self):
         self.partner.zip = "100000"

--- a/crm_assign_by_area/views/crm_lead.xml
+++ b/crm_assign_by_area/views/crm_lead.xml
@@ -1,8 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="crm_case_form_view_leads" model="ir.ui.view">
+        <field name="name">CRM Lead: add button Assign Salesperson</field>
+        <field name="model">crm.lead</field>
+        <field name="inherit_id" ref="crm.crm_case_form_view_leads"/>
+        <field name="arch" type="xml">
+            <xpath expr="//header/button[last()]" position="after">
+                <button name="action_assign_salesperson"
+                        string="Assign Salesperson"
+                        type="object"
+                        class="oe_highlight"
+                        />
+            </xpath>
+        </field>
+    </record>
+
     <record id="crm_case_form_view_oppor" model="ir.ui.view">
-        <field name="name">crm.lead.form.opportunity</field>
+        <field name="name">CRM Opportunity: add button Assign Salesperson</field>
         <field name="model">crm.lead</field>
         <field name="inherit_id" ref="crm.crm_case_form_view_oppor"/>
         <field name="arch" type="xml">
@@ -11,8 +26,7 @@
                         string="Assign Salesperson"
                         type="object"
                         class="oe_highlight"
-                        attrs="{'invisible': ['|', ('partner_id', '=', False)]}"
-                />
+                        />
             </xpath>
         </field>
     </record>

--- a/crm_assign_by_area/wizard/assign_salesperson_by_area_wizard.py
+++ b/crm_assign_by_area/wizard/assign_salesperson_by_area_wizard.py
@@ -19,10 +19,7 @@ class AssignSalespersonByAreaWizard(models.Model):
         res = super().default_get(fields)
 
         active_record = self.get_active_record()
-        if self._context.get("active_model") == "crm.lead":
-            territories = active_record.partner_id.territory_ids
-        else:
-            territories = active_record.territory_ids
+        territories = active_record.territory_ids
         salespersons = territories.mapped("salesperson_id")
         vals = {
             "available_territory_ids": [(6, 0, territories.ids)],


### PR DESCRIPTION
Instead of using the territories defined on the partner related
to the lead, the territories are defined directly on the lead.

At the stage of a lead, the crm.lead object is not linked to a partner.