### PR TITLE
TA#43464 set high sale order line sequence

### DIFF
--- a/sale_kit/models/sale_order_line.py
+++ b/sale_kit/models/sale_order_line.py
@@ -10,6 +10,8 @@ class SaleOrderLine(models.Model):
 
     _inherit = "sale.order.line"
 
+    sequence = fields.Integer(default=99999)
+
     is_kit = fields.Boolean()
     kit_sequence = fields.Integer()
     is_kit_component = fields.Boolean()


### PR DESCRIPTION
In vanilla Odoo, the default value is 10.

Without this code fix, adding a new component to an existing kit will not work
if the sale order has more than 10 lines.

When adding a new line, a value of 10 does not reflect properly the placement
of the line in the list view. It results in an unexpected permutation of the lines
when the sequences are recomputed.