### PR TITLE
TA#43480 fix case of product filter on sales order

### DIFF
--- a/sale_rental/models/product_product.py
+++ b/sale_rental/models/product_product.py
@@ -28,8 +28,8 @@ class Product(models.Model):
     def _search(self, args, *args_, **kwargs):
         is_rental_sale_order = self._context.get("is_rental_sale_order")
 
-        if is_rental_sale_order is not None and _should_filter_products(self.env):
-            args = AND([args or [], [("can_be_rented", "=", is_rental_sale_order)]])
+        if is_rental_sale_order and _should_filter_products(self.env):
+            args = AND([args or [], [("can_be_rented", "=", True)]])
 
         return super()._search(args, *args_, **kwargs)
 

--- a/sale_rental/tests/test_product.py
+++ b/sale_rental/tests/test_product.py
@@ -60,7 +60,7 @@ class TestProductSearch(common.SavepointCase):
 
     def test_search__not_rental_order(self):
         context = {"is_rental_sale_order": False}
-        assert not self._search(context)
+        assert self._search(context)
 
     def test_search__not_rental_order__not_rental_product(self):
         context = {"is_rental_sale_order": False}


### PR DESCRIPTION
On standard sales order, it is important to allow selling products
that can be rented.

The filter should only be applied on rental orders.